### PR TITLE
Support Railway deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,21 @@ mcp dev src/mcp_azure_devops/server.py
 mcp install src/mcp_azure_devops/server.py --name "Azure DevOps Assistant"
 ```
 
+### Deploying to Railway
+
+When deploying on [Railway](https://railway.app/), the platform assigns a port
+via the `PORT` environment variable. The server automatically uses this value.
+Ensure the host is accessible by setting `FASTMCP_HOST` to `0.0.0.0`.
+
+Example start command:
+
+```bash
+FASTMCP_HOST=0.0.0.0 PORT=$PORT mcp-azure-devops --transport sse
+```
+
+This runs the server over HTTP using SSE so it can receive requests from the
+internet.
+
 ## Usage Examples
 
 ### Query Work Items

--- a/src/mcp_azure_devops/server.py
+++ b/src/mcp_azure_devops/server.py
@@ -4,6 +4,7 @@ Azure DevOps MCP Server
 A simple MCP server that exposes Azure DevOps capabilities.
 """
 import argparse
+import os
 
 from mcp.server.fastmcp import FastMCP
 
@@ -12,6 +13,13 @@ from mcp_azure_devops.utils import register_all_prompts
 
 # Create a FastMCP server instance with a name
 mcp = FastMCP("Azure DevOps")
+
+# Adjust host and port when deployed on platforms like Railway
+if port := os.environ.get("PORT"):
+    # Railway provides the desired port in the PORT env var
+    mcp.settings.port = int(port)
+    # Bind to all interfaces if the host has not been overridden
+    mcp.settings.host = os.environ.get("FASTMCP_HOST", "0.0.0.0")
 
 # Register all features
 register_all(mcp)


### PR DESCRIPTION
## Summary
- make server read PORT env var when deployed to hosts like Railway
- document how to run the server on Railway

## Testing
- `pytest -q`
- `ruff check src/mcp_azure_devops/server.py`

------
https://chatgpt.com/codex/tasks/task_e_684aaa6d7418832694cb76e788dd9cfc