### PR TITLE
Fix server port handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,14 @@ mcp install src/mcp_azure_devops/server.py --name "Azure DevOps Assistant"
 ### Deploying to Railway
 
 When deploying on [Railway](https://railway.app/), the platform assigns a port
-via the `PORT` environment variable. The server automatically uses this value.
-Ensure the host is accessible by setting `FASTMCP_HOST` to `0.0.0.0`.
+via the `PORT` environment variable. FastMCP expects the port in
+`FASTMCP_PORT`, so be sure to map the value. Also ensure the host is accessible
+by setting `FASTMCP_HOST` to `0.0.0.0`.
 
 Example start command:
 
 ```bash
-FASTMCP_HOST=0.0.0.0 PORT=$PORT mcp-azure-devops --transport sse
+FASTMCP_HOST=0.0.0.0 FASTMCP_PORT=$PORT mcp-azure-devops --transport sse
 ```
 
 This runs the server over HTTP using SSE so it can receive requests from the

--- a/src/mcp_azure_devops/server.py
+++ b/src/mcp_azure_devops/server.py
@@ -23,11 +23,17 @@ print("Prompts registered")
 
 def main():
     """Entry point for the command-line script."""
-    port = int(os.environ.get("PORT", 8080))
+    # Prefer the FastMCP specific port if provided, otherwise fall back to the
+    # generic PORT variable which some platforms (like Railway) populate.
+    port = int(os.environ.get("FASTMCP_PORT", os.environ.get("PORT", 8080)))
     host = os.environ.get("FASTMCP_HOST", "0.0.0.0")
-    
+
     print(f"Starting FastMCP server on {host}:{port}")
-    
+
+    # Ensure the FastMCP instance uses the expected host/port
+    mcp.settings.host = host
+    mcp.settings.port = port
+
     # Let FastMCP handle the server itself
     mcp.run(transport="sse")
 


### PR DESCRIPTION
## Summary
- propagate host/port settings to FastMCP
- document FASTMCP_PORT env var in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'azure')*

------
https://chatgpt.com/codex/tasks/task_e_68702b992aa08326bafee624d1d34f24